### PR TITLE
URL-encode/decode password and parameter values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ License: MIT + file LICENSE
 Imports: 
     DBI,
     dplyr,
-    methods
+    methods,
+    utils
 Suggests: 
     odbc,
     RMariaDB,

--- a/R/dbpath.R
+++ b/R/dbpath.R
@@ -44,6 +44,9 @@ dbpath <- function(url) {
     }
   }
 
+  if (nzchar(parsed_url[["username"]])) {
+    parsed_url[["username"]] <- utils::URLdecode(parsed_url[["username"]])
+  }
   if (nzchar(parsed_url[["password"]])) {
     parsed_url[["password"]] <- utils::URLdecode(parsed_url[["password"]])
   }
@@ -114,7 +117,7 @@ format.dbpath <- function(x, hide_password = FALSE, ...) {
 
   paste0(
     x[["name"]], "://",
-    x[["username"]],
+    url_encode(x[["username"]]),
     password(),
     if (is_not_empty(x[["username"]]) || is_not_empty(x[["password"]]))
       "@",

--- a/R/dbpath.R
+++ b/R/dbpath.R
@@ -79,8 +79,10 @@ setMethod("dbConnect", "dbpath", function(drv) {
 
 #' Print a dbpath object
 #'
-#' @param x A dbpath object to print
-#' @param hide_password replace password with '****'
+#' @param x A [dbpath()] object to print
+#' @param hide_password Replace password with '****' if [TRUE]. Passwords are
+#'   hidden by default when printing a [dbpath()] object, but are revealed when
+#'   using `format()` to construct a URL.
 #' @param url_encode If [TRUE], the password and query paraemeters are
 #'   URL-encoded. Turned on by default in `format()`.
 #' @param ... extra arguments
@@ -96,7 +98,7 @@ print.dbpath <- function(x, hide_password = TRUE, ..., url_encode = FALSE) {
 #'
 #' Returns a formatted dbpath URL as a character string.
 #'
-#' @param x The [dbpath()] object
+#' @param x A [dbpath()] object to format
 #' @inheritParams print.dbpath
 #'
 #' @return A character string consisting of a dbpath URL, e.g

--- a/R/dbpath.R
+++ b/R/dbpath.R
@@ -175,7 +175,7 @@ format_params <- function(params) {
   }
 
   params <- vapply(names(params), FUN.VALUE = character(1), function(name) {
-    sprintf("%s=%s", name, params[[name]])
+    sprintf("%s=%s", name, utils::URLencode(params[[name]]))
   })
 
   params <- paste(params, collapse = "&")

--- a/R/dbpath.R
+++ b/R/dbpath.R
@@ -170,7 +170,13 @@ format.dbpath <- function(x, hide_password = FALSE, ...) {
   as.list(values)
 }
 
-format_params <- function(params) {
+format_params <- function(params, url_encode = TRUE) {
+  encoder <- if (!url_encode) {
+    identity
+  } else {
+    function(x) utils::URLencode(x, reserved = TRUE)
+  }
+
   # params is a named list of parameter values
   if (!is.list(params) || is.null(names(params))) {
     stop("`params` must be a named list of parameter name-value pairs.")
@@ -180,7 +186,7 @@ format_params <- function(params) {
   }
 
   params <- vapply(names(params), FUN.VALUE = character(1), function(name) {
-    sprintf("%s=%s", name, utils::URLencode(params[[name]]))
+    sprintf("%s=%s", name, encoder(params[[name]]))
   })
 
   params <- paste(params, collapse = "&")

--- a/R/dbpath.R
+++ b/R/dbpath.R
@@ -108,7 +108,7 @@ format.dbpath <- function(x, hide_password = FALSE, ...) {
     if (!is_not_empty(x[["password"]])) return("")
     if (hide_password) return(":****")
 
-    pwd <- utils::URLencode(x[["password"]], reserved = TRUE)
+    pwd <- url_encode(x[["password"]])
     paste0(":", pwd)
   }
 
@@ -195,7 +195,7 @@ format_params <- function(params) {
   }
 
   params <- vapply(names(params), FUN.VALUE = character(1), function(name) {
-    sprintf("%s=%s", name, utils::URLencode(params[[name]], reserved = TRUE))
+    sprintf("%s=%s", name, url_encode(params[[name]]))
   })
 
   params <- paste(params, collapse = "&")

--- a/R/dbpath.R
+++ b/R/dbpath.R
@@ -40,7 +40,12 @@ dbpath <- function(url) {
 
     if (length(tokens) > 1) {
       parsed_url[["params"]] <- .rfc_1738_parse_query(tokens[2])
+      parsed_url[["params"]] <- lapply(parsed_url[["params"]], utils::URLdecode)
     }
+  }
+
+  if (nzchar(parsed_url[["password"]])) {
+    parsed_url[["password"]] <- utils::URLdecode(parsed_url[["password"]])
   }
 
   structure(parsed_url, class = "dbpath")

--- a/R/dbpath_build.R
+++ b/R/dbpath_build.R
@@ -55,7 +55,7 @@ dbpath_build <- function(
 
   if (!is.null(password)) {
     assert_is_string(password)
-    url <- paste0(url, ":", utils::URLencode(password, reserved = TRUE))
+    url <- paste0(url, ":", url_encode(password))
   }
 
   url <- paste0(url, "@")

--- a/R/dbpath_build.R
+++ b/R/dbpath_build.R
@@ -55,7 +55,7 @@ dbpath_build <- function(
 
   if (!is.null(password)) {
     assert_is_string(password)
-    url <- paste0(url, ":", password)
+    url <- paste0(url, ":", utils::URLencode(password, reserved = TRUE))
   }
 
   url <- paste0(url, "@")

--- a/R/dbpath_build.R
+++ b/R/dbpath_build.R
@@ -50,7 +50,7 @@ dbpath_build <- function(
 
   if (!is.null(username)) {
     assert_is_string(username)
-    url <- paste0(url, username)
+    url <- paste0(url, url_encode(username))
   }
 
   if (!is.null(password)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,3 +11,7 @@ is_not_empty <- function(x) {
   if (is.character(x) && !any(nzchar(x))) return(FALSE)
   TRUE
 }
+
+url_encode <- function(x) {
+  utils::URLencode(x, reserved = TRUE)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,5 +13,6 @@ is_not_empty <- function(x) {
 }
 
 url_encode <- function(x) {
+  if (is.null(x)) return("")
   utils::URLencode(x, reserved = TRUE)
 }

--- a/man/format.dbpath.Rd
+++ b/man/format.dbpath.Rd
@@ -7,9 +7,11 @@
 \method{format}{dbpath}(x, hide_password = FALSE, ..., url_encode = TRUE)
 }
 \arguments{
-\item{x}{The \code{\link[=dbpath]{dbpath()}} object}
+\item{x}{A \code{\link[=dbpath]{dbpath()}} object to format}
 
-\item{hide_password}{replace password with '****'}
+\item{hide_password}{Replace password with '****' if \link{TRUE}. Passwords are
+hidden by default when printing a \code{\link[=dbpath]{dbpath()}} object, but are revealed when
+using \code{format()} to construct a URL.}
 
 \item{...}{extra arguments}
 

--- a/man/format.dbpath.Rd
+++ b/man/format.dbpath.Rd
@@ -4,7 +4,7 @@
 \alias{format.dbpath}
 \title{Format a dbpath object}
 \usage{
-\method{format}{dbpath}(x, hide_password = FALSE, ..., url_encode = TRUE)
+\method{format}{dbpath}(x, hide_password = FALSE, ...)
 }
 \arguments{
 \item{x}{A \code{\link[=dbpath]{dbpath()}} object to format}
@@ -14,9 +14,6 @@ hidden by default when printing a \code{\link[=dbpath]{dbpath()}} object, but ar
 using \code{format()} to construct a URL.}
 
 \item{...}{extra arguments}
-
-\item{url_encode}{If \link{TRUE}, the password and query paraemeters are
-URL-encoded. Turned on by default in \code{format()}.}
 }
 \value{
 A character string consisting of a dbpath URL, e.g

--- a/man/format.dbpath.Rd
+++ b/man/format.dbpath.Rd
@@ -4,7 +4,7 @@
 \alias{format.dbpath}
 \title{Format a dbpath object}
 \usage{
-\method{format}{dbpath}(x, hide_password = FALSE, ...)
+\method{format}{dbpath}(x, hide_password = FALSE, ..., url_encode = TRUE)
 }
 \arguments{
 \item{x}{The \code{\link[=dbpath]{dbpath()}} object}
@@ -12,6 +12,9 @@
 \item{hide_password}{replace password with '****'}
 
 \item{...}{extra arguments}
+
+\item{url_encode}{If \link{TRUE}, the password and query paraemeters are
+URL-encoded. Turned on by default in \code{format()}.}
 }
 \value{
 A character string consisting of a dbpath URL, e.g

--- a/man/print.dbpath.Rd
+++ b/man/print.dbpath.Rd
@@ -2,17 +2,20 @@
 % Please edit documentation in R/dbpath.R
 \name{print.dbpath}
 \alias{print.dbpath}
-\title{print a dbpath object}
+\title{Print a dbpath object}
 \usage{
-\method{print}{dbpath}(x, hide_password = TRUE, ...)
+\method{print}{dbpath}(x, hide_password = TRUE, ..., url_encode = FALSE)
 }
 \arguments{
-\item{x}{an item to print}
+\item{x}{A dbpath object to print}
 
 \item{hide_password}{replace password with '****'}
 
 \item{...}{extra arguments}
+
+\item{url_encode}{If \link{TRUE}, the password and query paraemeters are
+URL-encoded. Turned on by default in \code{format()}.}
 }
 \description{
-print a dbpath object
+Print a dbpath object
 }

--- a/man/print.dbpath.Rd
+++ b/man/print.dbpath.Rd
@@ -7,9 +7,11 @@
 \method{print}{dbpath}(x, hide_password = TRUE, ..., url_encode = FALSE)
 }
 \arguments{
-\item{x}{A dbpath object to print}
+\item{x}{A \code{\link[=dbpath]{dbpath()}} object to print}
 
-\item{hide_password}{replace password with '****'}
+\item{hide_password}{Replace password with '****' if \link{TRUE}. Passwords are
+hidden by default when printing a \code{\link[=dbpath]{dbpath()}} object, but are revealed when
+using \code{format()} to construct a URL.}
 
 \item{...}{extra arguments}
 

--- a/man/print.dbpath.Rd
+++ b/man/print.dbpath.Rd
@@ -4,7 +4,7 @@
 \alias{print.dbpath}
 \title{Print a dbpath object}
 \usage{
-\method{print}{dbpath}(x, hide_password = TRUE, ..., url_encode = FALSE)
+\method{print}{dbpath}(x, hide_password = TRUE, ...)
 }
 \arguments{
 \item{x}{A \code{\link[=dbpath]{dbpath()}} object to print}
@@ -14,9 +14,6 @@ hidden by default when printing a \code{\link[=dbpath]{dbpath()}} object, but ar
 using \code{format()} to construct a URL.}
 
 \item{...}{extra arguments}
-
-\item{url_encode}{If \link{TRUE}, the password and query paraemeters are
-URL-encoded. Turned on by default in \code{format()}.}
 }
 \description{
 Print a dbpath object

--- a/tests/testthat/_snaps/dbpath.md
+++ b/tests/testthat/_snaps/dbpath.md
@@ -6,3 +6,35 @@
       <dbpath>
       a+b://c:****@d
 
+# dbpath url-decodes and encodes passwords
+
+    Code
+      print(dbpath(url_pwd), hide_password = FALSE)
+    Output
+      <dbpath>
+      drv://user:p@ssw*rd@host
+
+---
+
+    Code
+      print(dbpath(url_pwd), hide_password = FALSE, url_encode = FALSE)
+    Output
+      <dbpath>
+      drv://user:p@ssw*rd@host
+
+# dbpath url-decodes and encodes query parameters
+
+    Code
+      print(dbpath(url_q))
+    Output
+      <dbpath>
+      drv://user@host/db?foo=bar and baz
+
+---
+
+    Code
+      print(dbpath(url_q), url_encode = FALSE)
+    Output
+      <dbpath>
+      drv://user@host/db?foo=bar and baz
+

--- a/tests/testthat/_snaps/dbpath.md
+++ b/tests/testthat/_snaps/dbpath.md
@@ -6,13 +6,13 @@
       <dbpath>
       a+b://c:****@d
 
-# dbpath url-decodes and encodes passwords
+# dbpath url-decodes and encodes usernname and password
 
     Code
-      print(dbpath(url_pwd), hide_password = FALSE)
+      print(dbpath(url_user_pass), hide_password = FALSE)
     Output
       <dbpath>
-      drv://user:p%40ssw%2Ard@host
+      drv://%24%40lly:p%40ssw%2Ard@host
 
 # dbpath url-decodes and encodes query parameters
 

--- a/tests/testthat/_snaps/dbpath.md
+++ b/tests/testthat/_snaps/dbpath.md
@@ -12,15 +12,7 @@
       print(dbpath(url_pwd), hide_password = FALSE)
     Output
       <dbpath>
-      drv://user:p@ssw*rd@host
-
----
-
-    Code
-      print(dbpath(url_pwd), hide_password = FALSE, url_encode = FALSE)
-    Output
-      <dbpath>
-      drv://user:p@ssw*rd@host
+      drv://user:p%40ssw%2Ard@host
 
 # dbpath url-decodes and encodes query parameters
 
@@ -28,13 +20,5 @@
       print(dbpath(url_q))
     Output
       <dbpath>
-      drv://user@host/db?foo=bar and baz
-
----
-
-    Code
-      print(dbpath(url_q), url_encode = FALSE)
-    Output
-      <dbpath>
-      drv://user@host/db?foo=bar and baz
+      drv://user@host/db?foo=bar%20and%20baz
 

--- a/tests/testthat/test-dbpath.R
+++ b/tests/testthat/test-dbpath.R
@@ -12,3 +12,51 @@ test_that("dbpath print hides passwords", {
     "a+b://c:****@d"
   )
 })
+
+test_that("dbpath url-decodes and encodes passwords", {
+  url_pwd <- "drv://user:p%40ssw%2Ard@host"
+
+  # decoded on ingest
+  expect_equal(
+    dbpath(url_pwd)$password,
+    "p@ssw*rd"
+  )
+
+  # re-encoded when forming a URL
+  expect_equal(
+    format(dbpath(url_pwd)),
+    url_pwd
+  )
+
+  # encoded in the print method or not if requested
+  expect_snapshot(
+    print(dbpath(url_pwd), hide_password = FALSE)
+  )
+  expect_snapshot(
+    print(dbpath(url_pwd), hide_password = FALSE, url_encode = FALSE)
+  )
+})
+
+test_that("dbpath url-decodes and encodes query parameters", {
+  url_q <- "drv://user@host/db?foo=bar%20and%20baz"
+
+  # decoded on ingest
+  expect_equal(
+    dbpath(url_q)$params$foo,
+    "bar and baz"
+  )
+
+  # re-encoded when forming a URL
+  expect_equal(
+    format(dbpath(url_q)),
+    url_q
+  )
+
+  # encoded in the print method or not if requested
+  expect_snapshot(
+    print(dbpath(url_q))
+  )
+  expect_snapshot(
+    print(dbpath(url_q), url_encode = FALSE)
+  )
+})

--- a/tests/testthat/test-dbpath.R
+++ b/tests/testthat/test-dbpath.R
@@ -13,31 +13,35 @@ test_that("dbpath print hides passwords", {
   )
 })
 
-test_that("dbpath url-decodes and encodes passwords", {
-  url_pwd <- "drv://user:p%40ssw%2Ard@host"
+test_that("dbpath url-decodes and encodes usernname and password", {
+  url_user_pass <- "drv://%24%40lly:p%40ssw%2Ard@host"
 
-  # decoded on ingest
+  # decoded internally
   expect_equal(
-    dbpath(url_pwd)$password,
+    dbpath(url_user_pass)$password,
     "p@ssw*rd"
+  )
+  expect_equal(
+    dbpath(url_user_pass)$username,
+    "$@lly"
   )
 
   # re-encoded when forming a URL
   expect_equal(
-    format(dbpath(url_pwd)),
-    url_pwd
+    format(dbpath(url_user_pass)),
+    url_user_pass
   )
 
   # encoded in the print method
   expect_snapshot(
-    print(dbpath(url_pwd), hide_password = FALSE)
+    print(dbpath(url_user_pass), hide_password = FALSE)
   )
 })
 
 test_that("dbpath url-decodes and encodes query parameters", {
   url_q <- "drv://user@host/db?foo=bar%20and%20baz"
 
-  # decoded on ingest
+  # decoded internally
   expect_equal(
     dbpath(url_q)$params$foo,
     "bar and baz"

--- a/tests/testthat/test-dbpath.R
+++ b/tests/testthat/test-dbpath.R
@@ -28,12 +28,9 @@ test_that("dbpath url-decodes and encodes passwords", {
     url_pwd
   )
 
-  # encoded in the print method or not if requested
+  # encoded in the print method
   expect_snapshot(
     print(dbpath(url_pwd), hide_password = FALSE)
-  )
-  expect_snapshot(
-    print(dbpath(url_pwd), hide_password = FALSE, url_encode = FALSE)
   )
 })
 
@@ -52,11 +49,8 @@ test_that("dbpath url-decodes and encodes query parameters", {
     url_q
   )
 
-  # encoded in the print method or not if requested
+  # encoded in the print method
   expect_snapshot(
     print(dbpath(url_q))
-  )
-  expect_snapshot(
-    print(dbpath(url_q), url_encode = FALSE)
   )
 })

--- a/tests/testthat/test-dbpath_build.R
+++ b/tests/testthat/test-dbpath_build.R
@@ -123,10 +123,10 @@ test_that("dbpath_build() url-encodes passwords and query params", {
       dbpath_build(
         "drv",
         username = "user",
-        password = utils::URLencode("p@ssw*rd", reserved = TRUE),
+        password = url_encode("p@ssw*rd"),
         host = "host",
         database = "db",
-        params = list(foo = utils::URLencode("bar and baz", reserved = TRUE))
+        params = list(foo = url_encode("bar and baz"))
       )
     ),
     url_exp

--- a/tests/testthat/test-dbpath_build.R
+++ b/tests/testthat/test-dbpath_build.R
@@ -100,3 +100,35 @@ test_that("dbpath_build() throws errors on bad input", {
     dbpath_build("driver", params = c("foo", "bar"))
   )
 })
+
+test_that("dbpath_build() url-encodes passwords and query params", {
+  url_exp <- "drv://user:p%40ssw%2Ard@host/db?foo=bar%20and%20baz"
+  expect_equal(
+    format(
+      dbpath_build(
+        "drv",
+        username = "user",
+        password = "p@ssw*rd",
+        host = "host",
+        database = "db",
+        params = list(foo = "bar and baz")
+      )
+    ),
+    url_exp
+  )
+
+  # it also doesn't re-encode previously encoded values
+  expect_equal(
+    format(
+      dbpath_build(
+        "drv",
+        username = "user",
+        password = utils::URLencode("p@ssw*rd", reserved = TRUE),
+        host = "host",
+        database = "db",
+        params = list(foo = utils::URLencode("bar and baz", reserved = TRUE))
+      )
+    ),
+    url_exp
+  )
+})


### PR DESCRIPTION
Closes #6 

Password and query parameter values are URL-decoded on ingest by `dbpath()`. The print and format methods re-encode these values appropriately.

`dbpath_build()` also encodes `password` and query param values before passing to `dbpath()`; fortunately `utils::URLencode()` avoids re-encoding previously encoded strings.