### PR TITLE
Don't load driver packages until requested

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Imports:
     DBI,
     dplyr,
     methods,
+    rlang,
     utils
 Suggests: 
     odbc,

--- a/R/drivers.R
+++ b/R/drivers.R
@@ -12,9 +12,14 @@ simple_config <- function() {
 }
 
 import_from <- function(pkg, func_name) {
-  # standard eval for pkg::func_name
-  requireNamespace(pkg)
-  function() get(func_name, loadNamespace(pkg))
+  function() {
+    # standard eval for pkg::func_name, but delayed
+    rlang::check_installed(
+      pkg = pkg,
+      reason = sprintf("to connect to the database with `%s()`.", func_name)
+    )
+    asNamespace(pkg)[[func_name]]
+  }
 }
 
 get_dialect_name <- function(path) {


### PR DESCRIPTION
Fixes #7

Adds a dependency on {rlang}, but I think it's worth it (and we already implicitly depend on {rlang} anyway via {dplyr}).

Quick version: `import_from()` creates a function that returns the database driver, but waits to check if the package is installed until the driver is requested.

Here's an example where I've uninstalled `RMariaDB`:

```r
library(dbpath)

db_url <- dbpath("mysql://localhost:1234")

DBI::dbConnect(db_url)
#> ℹ The package `RMariaDB` is required to connect to the database with `MariaDB()`.
#> ✖ Would you like to install it?
#> 
#> 1: Yes
#> 2: No
```